### PR TITLE
Add script for retrieving video metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # ytbuddy
 
-This repository contains a helper script `fetch_videos.py` that retrieves the
-list of video URLs from a YouTube channel.
+This repository contains helper scripts for working with YouTube channels.
+
+- `fetch_videos.py` retrieves the list of video URLs from a channel.
+- `fetch_metadata.py` outputs the full metadata for every video in a channel as
+  JSON.
 
 ## Requirements
 
@@ -17,11 +20,14 @@ development tasks.
 
 ## Usage
 
-Run the script with a channel URL. It accepts URLs that include the `/videos`
-segment or just the channel root URL.
+Run the scripts with a channel URL. They accept URLs that include the
+`/videos` segment or just the channel root URL.
 
 ```bash
 python fetch_videos.py https://www.youtube.com/@sequoiacapital/videos
+python fetch_metadata.py https://www.youtube.com/@sequoiacapital
 ```
 
-The script outputs the URLs of the videos on the channel, one per line.
+`fetch_videos.py` prints each video URL on a separate line, while
+`fetch_metadata.py` prints a JSON array containing the metadata objects for all
+videos.

--- a/fetch_metadata.py
+++ b/fetch_metadata.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Fetch metadata for all videos in a YouTube channel.
+
+Usage:
+    python fetch_metadata.py CHANNEL_URL
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any, Dict, List
+
+from yt_dlp import YoutubeDL
+
+from fetch_videos import _normalize_channel_url, fetch_video_urls
+
+
+def fetch_video_metadata(video_url: str) -> Dict[str, Any]:
+    """Return metadata for a single YouTube video."""
+    ydl_opts = {
+        "skip_download": True,
+        "quiet": True,
+    }
+    with YoutubeDL(ydl_opts) as ydl:
+        info = ydl.extract_info(video_url, download=False)
+    return info
+
+
+def fetch_all_metadata(channel_url: str) -> List[Dict[str, Any]]:
+    """Return metadata for all videos on the channel."""
+    channel_root = _normalize_channel_url(channel_url)
+    video_urls = fetch_video_urls(channel_root)
+    metadata = []
+    for url in video_urls:
+        metadata.append(fetch_video_metadata(url))
+    return metadata
+
+
+def main(args: List[str]) -> None:
+    if len(args) != 1:
+        print("Usage: python fetch_metadata.py CHANNEL_URL")
+        raise SystemExit(1)
+    all_metadata = fetch_all_metadata(args[0])
+    print(json.dumps(all_metadata, indent=2))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
## Summary
- add `fetch_metadata.py` to pull full metadata for each video in a channel
- document the new script in the README

## Testing
- `python fetch_metadata.py` *(fails: ModuleNotFoundError: No module named 'yt_dlp')*