### PR TITLE
Enable wide layout in Streamlit UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -137,6 +137,8 @@ def run_streamlit() -> None:
     """Launch the Streamlit UI."""
     import streamlit as st
 
+    st.set_page_config(page_title="YouTube Metadata Fetcher", layout="wide")
+
     st.title("YouTube Metadata Fetcher")
 
     channel_url = st.text_input("YouTube Channel URL")


### PR DESCRIPTION
## Summary
- set `st.set_page_config(..., layout="wide")` to use Streamlit's wide layout

## Testing
- `flake8` *(fails: command not found)*
- `python -m flake8` *(fails: No module named flake8)*
- `python -m pytest -q` *(fails: No module named pytest)*
